### PR TITLE
Update podcast link to frndshiptime.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         <div>&copy; 2026</div>
         <div class="c-socials">
           <a href="mailto:parthswat@gmail.com">Email</a>
-          <a href="#">Podcast</a>
+          <a href="https://frndshiptime.com">Podcast</a>
           <a href="blog.html">Blog</a>
           <a href="feed.xml">RSS</a>
         </div>


### PR DESCRIPTION
## Summary
Updated the podcast navigation link to point to the actual podcast website instead of a placeholder.

## Changes
- Changed the podcast link href from `#` (placeholder) to `https://frndshiptime.com`

## Details
This change enables users to navigate to the podcast website from the footer navigation. The link was previously non-functional as it pointed to a hash anchor.

https://claude.ai/code/session_0159CryU3gpwNRvFnJkZtJSo